### PR TITLE
fix: resolve lint errors in test files

### DIFF
--- a/src/commands/ticket/create.test.ts
+++ b/src/commands/ticket/create.test.ts
@@ -61,6 +61,7 @@ describe('createTicket Pure Function', () => {
 
       expect(result.success).toBe(true);
       // Strip ANSI color codes for comparison
+      // eslint-disable-next-line no-control-regex
       const strippedMessage = result.message.replace(/\u001b\[[0-9;]*m/g, '');
       expect(strippedMessage).toContain('LOCATION:');
       expect(strippedMessage).not.toContain('Location:');

--- a/src/commands/ticket/list.test.ts
+++ b/src/commands/ticket/list.test.ts
@@ -100,6 +100,7 @@ describe('listTickets pure function', () => {
 
       expect(result.success).toBe(true);
       // Strip ANSI color codes for comparison
+      // eslint-disable-next-line no-control-regex
       const strippedMessage = result.message.replace(/\u001b\[[0-9;]*m/g, '');
       
       // Should use INFO: instead of LIST:


### PR DESCRIPTION
## Summary
- Fix no-control-regex lint errors in test files
- Add eslint-disable-next-line comments for ANSI color stripping regex patterns

## Changes
- : Added eslint-disable comment
- : Added eslint-disable comment

## Details
The regex patterns  are used to strip ANSI color codes from test output for assertion comparisons. These patterns contain control characters which trigger the no-control-regex lint rule. Since these patterns are intentional and necessary for testing, we disable the lint rule for these specific lines.

## Test Results
- All tests passing: 664/664 ✅
- TypeScript: No errors ✅
- Lint: No errors (only warnings) ✅