### PR TITLE
feat(#107): add 'ait3 install command review' and remove review from init

### DIFF
--- a/src/assets/commands/review.ts
+++ b/src/assets/commands/review.ts
@@ -1,0 +1,79 @@
+/**
+ * Multi-agent code review command guide template
+ * Provides structured approach for comprehensive code reviews using Claude and Gemini
+ */
+export const reviewTemplate = `# Multi-Agent Code Review
+
+Perform comprehensive code reviews using multiple AI perspectives.
+
+## Review Process
+
+### Step 1: Correctness Review (Claude)
+Review the current changes for correctness:
+- Logic errors and bugs
+- Edge case handling
+- Adherence to requirements
+- Code consistency
+
+### Step 2: Performance Review (Gemini)
+Switch to terminal and run:
+\`\`\`bash
+gemini -p "@src/ @tests/ Review these changes for performance:
+
+Focus on:
+- Algorithm efficiency
+- Database query optimization
+- Memory usage patterns
+- Potential bottlenecks
+- Async/await optimization"
+\`\`\`
+
+### Step 3: Security Review (Claude)
+Review the changes for security issues:
+- Input validation
+- Authentication/authorization
+- SQL injection risks
+- XSS vulnerabilities
+- Sensitive data exposure
+- Dependency vulnerabilities
+
+### Step 4: Synthesize Results
+Create a summary that includes:
+1. Critical issues from all reviews
+2. Conflicting recommendations (if any)
+3. Priority-ordered action items
+4. Overall assessment
+
+### Step 5: Document Decision
+After human review, document the decision:
+\`\`\`bash
+git add .
+git commit -m "review(#TICKET): implement review feedback
+
+Correctness: [summary of fixes]
+Performance: [optimizations made]
+Security: [vulnerabilities addressed]
+
+Human decision: [rationale for choices made]"
+\`\`\`
+
+## Quick Commands
+
+For specific review types:
+\`\`\`bash
+# Performance only
+gemini -p "@src/ Review this code for performance bottlenecks"
+
+# Security only  
+# In Claude: "Review this code for security vulnerabilities"
+
+# Architecture review
+gemini -p "@src/ @docs/ Is this architecture scalable and maintainable?"
+\`\`\`
+
+## Tips
+- Run reviews after GREEN phase, before REFACTOR
+- Document conflicting opinions in commit messages
+- Keep context focused on specific changes
+- Use ticket scope to limit review scope
+`;

--- a/src/commands/init/index.test.ts
+++ b/src/commands/init/index.test.ts
@@ -31,7 +31,7 @@ describe('initCommand - Redesigned', () => {
   });
 
   describe('basic functionality', () => {
-    it('should generate exactly 4 files', async () => {
+    it('should generate exactly 3 files', async () => {
       // Create minimal package.json for project detection
       await writeFile('package.json', JSON.stringify({ name: 'test-project' }));
       
@@ -39,11 +39,13 @@ describe('initCommand - Redesigned', () => {
       
       expect(result.success).toBe(true);
       
-      // Check all 4 files were created
+      // Check all 3 files were created
       await expect(access('CLAUDE.ait3.md')).resolves.toBeUndefined();
       await expect(access('.claude/CLAUDE.md')).resolves.toBeUndefined();
       await expect(access('.claude/commands/ait3-init')).resolves.toBeUndefined();
-      await expect(access('.claude/commands/review')).resolves.toBeUndefined();
+      
+      // Review command should NOT be created
+      await expect(access('.claude/commands/review')).rejects.toThrow();
       
       // Ensure settings.local.json was NOT created
       await expect(access('.claude/settings.local.json')).rejects.toThrow();
@@ -66,7 +68,7 @@ describe('initCommand - Redesigned', () => {
       await writeFile('CLAUDE.ait3.md', '# Old content');
       await mkdir('.claude/commands', { recursive: true });
       await writeFile('.claude/CLAUDE.md', '# Old minimal content');
-      await writeFile('.claude/commands/review', '# Old review content');
+      await writeFile('.claude/commands/ait3-init', '# Old ait3-init content');
       
       const result = await initCommand({});
       
@@ -77,10 +79,10 @@ describe('initCommand - Redesigned', () => {
       expect(newContent).not.toContain('Old content');
       expect(newContent).toContain('AIT³');
       
-      // Verify review command was overwritten
-      const reviewContent = await readFile('.claude/commands/review', 'utf-8');
-      expect(reviewContent).not.toContain('Old review content');
-      expect(reviewContent).toContain('Multi-Agent Code Review');
+      // Verify ait3-init command was overwritten
+      const ait3InitContent = await readFile('.claude/commands/ait3-init', 'utf-8');
+      expect(ait3InitContent).not.toContain('Old ait3-init content');
+      expect(ait3InitContent).toContain('Initialize Complete CLAUDE.md');
     });
   });
 
@@ -200,22 +202,13 @@ describe('initCommand - Redesigned', () => {
       expect(content).toContain('Optional but Recommended');
     });
 
-    it('should generate correct review command guide', async () => {
+    it('should NOT generate review command guide', async () => {
       const result = await initCommand({});
       
       expect(result.success).toBe(true);
       
-      const content = await readFile('.claude/commands/review', 'utf-8');
-      
-      // Check review command guide content
-      expect(content).toContain('Multi-Agent Code Review');
-      expect(content).toContain('Correctness Review (Claude)');
-      expect(content).toContain('Performance Review (Gemini)');
-      expect(content).toContain('Security Review (Claude)');
-      expect(content).toContain('Synthesize Results');
-      expect(content).toContain('Document Decision');
-      expect(content).toContain('gemini -p "@src/ @tests/');
-      expect(content).toContain('review(#TICKET): implement review feedback');
+      // Review command should NOT exist
+      await expect(access('.claude/commands/review')).rejects.toThrow();
     });
   });
 
@@ -253,10 +246,10 @@ describe('initCommand - Redesigned', () => {
       expect(result.message).toContain('SUCCESS');
       expect(result.message).toContain('claude');
       expect(result.message).toContain('/ait3-init');
-      expect(result.message).toContain('4 files generated');
+      expect(result.message).toContain('3 files generated');
     });
 
-    it('should include review command in file list', async () => {
+    it('should NOT include review command in file list', async () => {
       await writeFile('package.json', JSON.stringify({ name: 'test-project' }));
       
       const result = await initCommand({});
@@ -266,7 +259,7 @@ describe('initCommand - Redesigned', () => {
       expect(result.message).toContain('CLAUDE.ait3.md');
       expect(result.message).toContain('.claude/CLAUDE.md');
       expect(result.message).toContain('.claude/commands/ait3-init');
-      expect(result.message).toContain('.claude/commands/review');
+      expect(result.message).not.toContain('.claude/commands/review');
     });
   });
 
@@ -466,7 +459,7 @@ describe('initCommand - Redesigned', () => {
         await expect(access('resources/js')).resolves.toBeUndefined();
       });
 
-      it('should generate review command for all project types', async () => {
+      it('should NOT generate review command for any project type', async () => {
         // Test TypeScript project
         await writeFile('package.json', JSON.stringify({
           devDependencies: { typescript: '^5.0.0' }
@@ -474,7 +467,7 @@ describe('initCommand - Redesigned', () => {
         
         let result = await initCommand({});
         expect(result.success).toBe(true);
-        await expect(access('.claude/commands/review')).resolves.toBeUndefined();
+        await expect(access('.claude/commands/review')).rejects.toThrow();
         
         // Clean up and test Laravel project
         await rm('.claude', { recursive: true, force: true });
@@ -484,7 +477,7 @@ describe('initCommand - Redesigned', () => {
         
         result = await initCommand({});
         expect(result.success).toBe(true);
-        await expect(access('.claude/commands/review')).resolves.toBeUndefined();
+        await expect(access('.claude/commands/review')).rejects.toThrow();
         
         // Clean up and test unknown project
         await rm('.claude', { recursive: true, force: true });
@@ -493,7 +486,7 @@ describe('initCommand - Redesigned', () => {
         
         result = await initCommand({});
         expect(result.success).toBe(true);
-        await expect(access('.claude/commands/review')).resolves.toBeUndefined();
+        await expect(access('.claude/commands/review')).rejects.toThrow();
       });
     });
   });

--- a/src/commands/init/index.ts
+++ b/src/commands/init/index.ts
@@ -9,8 +9,7 @@ import {
 } from '../../common/claude-md-templates.js';
 import { 
   AIT3_METHODOLOGY_TEMPLATE,
-  AIT3_INIT_GUIDE_TEMPLATE,
-  REVIEW_COMMAND_TEMPLATE 
+  AIT3_INIT_GUIDE_TEMPLATE
 } from '../../common/ait3-templates.js';
 import { analyzeProject, type ProjectAnalysis } from '../../common/project-analyzer.js';
 import { 
@@ -55,12 +54,11 @@ New workflow:
     // 2. Create directories
     await ensureMultipleDirectories(['.claude/commands']);
     
-    // 3. Generate base 4 files
+    // 3. Generate base 3 files (review command is now installed separately via 'ait3 install command review')
     const baseFiles = [
       generateClaudeAit3Md(analysis),
       generateMinimalClaudeMd(analysis),
-      generateAit3InitCommand(analysis.framework),
-      generateReviewCommand()
+      generateAit3InitCommand(analysis.framework)
     ];
     
     // 4. Generate hierarchical files based on framework
@@ -169,18 +167,11 @@ Adjust paths based on your project structure.`;
   await writeFile('.claude/commands/ait3-init', content, 'utf-8');
 }
 
-/**
- * Generate the multi-agent review command guide
- * This is project-agnostic, so no parameters needed
- */
-async function generateReviewCommand(): Promise<void> {
-  await writeFile('.claude/commands/review', REVIEW_COMMAND_TEMPLATE, 'utf-8');
-}
 
 function formatSuccessMessage(analysis: ProjectAnalysis): string {
   const messages: string[] = [];
   
-  messages.push(`${STYLES.success('SUCCESS:')} 4 files generated`);
+  messages.push(`${STYLES.success('SUCCESS:')} 3 files generated`);
   messages.push('');
   
   if (analysis.language !== 'Unknown') {
@@ -192,7 +183,6 @@ function formatSuccessMessage(analysis: ProjectAnalysis): string {
   messages.push('  - CLAUDE.ait3.md (temporary template)');
   messages.push('  - .claude/CLAUDE.md (minimal working version)');
   messages.push('  - .claude/commands/ait3-init (integration guide)');
-  messages.push('  - .claude/commands/review (multi-agent review guide)');
   messages.push('');
   
   // Add framework-specific messages

--- a/src/commands/install/command.test.ts
+++ b/src/commands/install/command.test.ts
@@ -97,6 +97,7 @@ describe('installCommand', () => {
       expect(result.message).toContain('gemini');
       expect(result.message).toContain('orchestrator');
       expect(result.message).toContain('ait3-init');
+      expect(result.message).toContain('review');
     });
 
     it('should install gemini command guide', async () => {
@@ -137,6 +138,21 @@ describe('installCommand', () => {
       expect(content).toContain('Generate CLAUDE.md');
       expect(content).toContain('Project Analysis');
     });
+
+    it('should install review command guide', async () => {
+      const args = { name: 'review' };
+      
+      const result = await installCommand(args);
+      
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('.claude/commands/review');
+      
+      const content = await readFile(join(testDir, '.claude/commands/review'), 'utf-8');
+      expect(content).toContain('Multi-Agent Code Review');
+      expect(content).toContain('Correctness Review (Claude)');
+      expect(content).toContain('Performance Review (Gemini)');
+      expect(content).toContain('Security Review (Claude)');
+    });
   });
 
   describe('install all commands', () => {
@@ -151,17 +167,20 @@ describe('installCommand', () => {
       expect(result.message).toContain('.claude/commands/gemini');
       expect(result.message).toContain('.claude/commands/orchestrator');
       expect(result.message).toContain('.claude/commands/ait3-init');
+      expect(result.message).toContain('.claude/commands/review');
       
       // Check all files
       const ait3Path = join(testDir, '.claude/commands/ait3');
       const geminiPath = join(testDir, '.claude/commands/gemini');
       const orchestratorPath = join(testDir, '.claude/commands/orchestrator');
       const ait3InitPath = join(testDir, '.claude/commands/ait3-init');
+      const reviewPath = join(testDir, '.claude/commands/review');
       
       await expect(access(ait3Path)).resolves.toBeUndefined();
       await expect(access(geminiPath)).resolves.toBeUndefined();
       await expect(access(orchestratorPath)).resolves.toBeUndefined();
       await expect(access(ait3InitPath)).resolves.toBeUndefined();
+      await expect(access(reviewPath)).resolves.toBeUndefined();
     });
 
     it('should install all commands with "all" name', async () => {
@@ -194,7 +213,7 @@ describe('installCommand', () => {
       
       expect(result.success).toBe(true);
       expect(result.message).toContain('Installation complete');
-      expect(result.message).toContain('4 file(s) installed');
+      expect(result.message).toContain('5 file(s) installed');
     });
   });
 

--- a/src/commands/install/command.ts
+++ b/src/commands/install/command.ts
@@ -7,38 +7,42 @@ import { ait3Template } from '../../assets/commands/ait3.js';
 import { geminiTemplate } from '../../assets/commands/gemini.js';
 import { orchestratorTemplate } from '../../assets/commands/orchestrator.js';
 import { ait3InitTemplate } from '../../assets/commands/ait3-init.js';
+import { reviewTemplate } from '../../assets/commands/review.js';
 interface InstallCommandArgs {
   name?: string;
   force?: boolean;
 }
+
+// Command name to template mapping
+const commandTemplates = {
+  ait3: ait3Template,
+  gemini: geminiTemplate,
+  orchestrator: orchestratorTemplate,
+  'ait3-init': ait3InitTemplate,
+  review: reviewTemplate
+} as const;
+
+type CommandName = keyof typeof commandTemplates;
 
 export async function installCommand(
   args: InstallCommandArgs
 ): Promise<CLIResult> {
   const { name = 'all', force = false } = args;
   
-  // Available command guides
-  const commandGuides = {
-    ait3: 'ait3',
-    gemini: 'gemini',
-    orchestrator: 'orchestrator',
-    'ait3-init': 'ait3-init'
-  };
-  
   // Determine which files to install
   let filesToInstall: Array<[string, string]> = [];
   
   if (name === 'all' || !name) {
     // Install all command guides
-    filesToInstall = Object.entries(commandGuides);
-  } else if (name in commandGuides) {
+    filesToInstall = Object.keys(commandTemplates).map(cmd => [cmd, cmd]);
+  } else if (name in commandTemplates) {
     // Install specific command guide
-    filesToInstall = [[name, commandGuides[name as keyof typeof commandGuides]]];
+    filesToInstall = [[name, name]];
   } else {
     // Invalid command name
     return {
       success: false,
-      message: `${STYLES.danger('ERROR: Unknown command')}: ${name}\n${STYLES.info('Available commands')}: ${Object.keys(commandGuides).join(', ')}`
+      message: `${STYLES.danger('ERROR: Unknown command')}: ${name}\n${STYLES.info('Available commands')}: ${Object.keys(commandTemplates).join(', ')}`
     };
   }
   
@@ -83,8 +87,11 @@ export async function installCommand(
       }
       
       if (shouldWrite) {
-        // Load template content
-        const templateContent = await getTemplateContent(cmdName);
+        // Get template content
+        const templateContent = commandTemplates[cmdName as CommandName];
+        if (!templateContent) {
+          throw new Error(`Template not found for command: ${cmdName}`);
+        }
         
         // Write file
         await writeFile(targetPath, templateContent, 'utf-8');
@@ -118,21 +125,6 @@ export async function installCommand(
   };
 }
 
-async function getTemplateContent(commandName: string): Promise<string> {
-  // Import templates based on command name
-  switch (commandName) {
-  case 'ait3':
-    return ait3Template;
-  case 'gemini':
-    return geminiTemplate;
-  case 'orchestrator':
-    return orchestratorTemplate;
-  case 'ait3-init':
-    return ait3InitTemplate;
-  default:
-    throw new Error(`Template not found for command: ${commandName}`);
-  }
-}
 
 export const commandCommand = new Command('command')
   .description('Install Claude command guides')

--- a/tests/integration/cli/init/init.integration.test.ts
+++ b/tests/integration/cli/init/init.integration.test.ts
@@ -23,25 +23,27 @@ describe('CLI Integration: ait3 init', () => {
   });
 
   describe('default behavior', () => {
-    it('should generate 4 files for Claude Code integration', async () => {
+    it('should generate 3 files for Claude Code integration', async () => {
       const { stdout, stderr } = await execAsync('node ' + join(originalCwd, 'dist/cli.js') + ' init');
 
       expect(stderr).toBe('');
       expect(stdout).toContain('SUCCESS:');
-      expect(stdout).toContain('4 files generated');
+      expect(stdout).toContain('3 files generated');
       expect(stdout).toContain('CLAUDE.ait3.md');
       expect(stdout).toContain('.claude/CLAUDE.md');
       expect(stdout).toContain('.claude/commands/ait3-init');
-      expect(stdout).toContain('.claude/commands/review');
+      expect(stdout).not.toContain('.claude/commands/review');
       expect(stdout).toContain('Next steps:');
       expect(stdout).toContain('Launch Claude Code: claude');
       expect(stdout).toContain('Run: /ait3-init');
 
-      // Verify all 4 files were created
+      // Verify all 3 files were created
       await expect(access(join(testDir, 'CLAUDE.ait3.md'))).resolves.not.toThrow();
       await expect(access(join(testDir, '.claude/CLAUDE.md'))).resolves.not.toThrow();
       await expect(access(join(testDir, '.claude/commands/ait3-init'))).resolves.not.toThrow();
-      await expect(access(join(testDir, '.claude/commands/review'))).resolves.not.toThrow();
+      
+      // Review command should NOT be created
+      await expect(access(join(testDir, '.claude/commands/review'))).rejects.toThrow();
     });
 
     it('should overwrite existing files without warning', async () => {
@@ -56,7 +58,7 @@ describe('CLI Integration: ait3 init', () => {
       
       expect(stderr).toBe('');
       expect(stdout).toContain('SUCCESS:');
-      expect(stdout).toContain('4 files generated');
+      expect(stdout).toContain('3 files generated');
       
       // Verify files still exist and are overwritten
       const secondContent = await readFile(join(testDir, 'CLAUDE.ait3.md'), 'utf-8');


### PR DESCRIPTION
## Summary
- Enable optional installation of review command guide via `ait3 install command review`
- Remove automatic review command creation from `ait3 init` (now generates 3 files instead of 4)
- Give users choice of when to install multi-agent review functionality

## Changes

### Added
- ✅ Created `/src/assets/commands/review.ts` with multi-agent review guide template
- ✅ Added 'review' to available commands in install system
- ✅ Support for `ait3 install command review`

### Removed  
- ❌ Removed automatic review command generation from `ait3 init`
- ❌ Removed `generateReviewCommand` function and REVIEW_COMMAND_TEMPLATE import from init
- ❌ Changed init output from 4 files to 3 files

### Refactored
- 🔧 Optimized `commandTemplates` object with direct template mapping
- 🔧 Removed redundant `getTemplateContent` function
- 🔧 Added TypeScript const assertion for better type safety

## Benefits
- 🎯 **User Choice**: Review command is optional, not forced on all projects
- 🧹 **Cleaner Init**: Simpler output with only essential files (3 instead of 4)
- 🔌 **Modular**: Install review functionality when needed
- 🏗️ **Consistent**: Follows established command installation pattern

## Usage
```bash
# Install review command guide separately
ait3 install command review

# Or install all commands including review
ait3 install command

# Init now generates only 3 files (review excluded)
ait3 init
```

## Test Results
- ✅ 714/714 tests passing (100% pass rate)
- ✅ TypeScript type-check successful
- ✅ All integration tests updated and passing

Closes #107

🤖 Generated with Claude Code